### PR TITLE
add state reset to accumulate

### DIFF
--- a/news/acc.rst
+++ b/news/acc.rst
@@ -1,0 +1,26 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* ``accumulate`` nodes now take in an additional optional kwarg
+  ``reset_stream``.
+  If provided, when this stream emits the ``accumulate`` node will be reset
+  to it's initial state.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/rapidz/core.py
+++ b/rapidz/core.py
@@ -760,7 +760,7 @@ class accumulate(Stream):
         If true then func should return both the state and the value to emit
         If false then both values are the same, and func returns one value
     reset_stream : Stream instance or None, optional
-        If not None, when the ``reset_node`` stream emits the accumulate node's
+        If not None, when the ``reset_stream`` stream emits the accumulate node's
         state will revert to the initial state (set by ``start``), defaults
         to None
     **kwargs:

--- a/rapidz/tests/test_core.py
+++ b/rapidz/tests/test_core.py
@@ -1338,7 +1338,7 @@ def test_accumulate():
 def test_accumulate_reset():
     a = Stream()
     rn = Stream()
-    b = a.accumulate(lambda x, y: x + y, reset_node=rn)
+    b = a.accumulate(lambda x, y: x + y, reset_stream=rn)
     L = b.sink_to_list()
     LL = []
 

--- a/rapidz/tests/test_core.py
+++ b/rapidz/tests/test_core.py
@@ -1317,3 +1317,38 @@ def test_destroy_pipeline():
     pipeline = source.map(operator.add).zip(source).sink(print)
     destroy_pipeline(source)
     assert pipeline.upstreams == []
+
+
+def test_accumulate():
+    a = Stream()
+    b = a.accumulate(lambda x, y: x + y)
+    L = b.sink_to_list()
+    LL = []
+
+    for i in range(10):
+        a.emit(i)
+        if len(LL) == 0:
+            LL.append(i)
+        else:
+            LL.append(i + LL[-1])
+
+    assert L == LL
+
+
+def test_accumulate_reset():
+    a = Stream()
+    rn = Stream()
+    b = a.accumulate(lambda x, y: x + y, reset_node=rn)
+    L = b.sink_to_list()
+    LL = []
+
+    for i in range(10):
+        if i == 5:
+            rn.emit('hi')
+        a.emit(i)
+        if len(LL) == 0 or i == 5:
+            LL.append(i)
+        else:
+            LL.append(i + LL[-1])
+
+    assert L == LL


### PR DESCRIPTION
During the operation of a pipeline it may be necessary to clear the state in an accumulate node or restore the initial state. For instance during a temperature scan we also perform an inner scan of summing images until a threshold is met. This will require us to clear the accumulate state once the threshold is met and the next set of images are acquired. One way to handle this (which is currently the only way to handle this) is to have a second node which resets the state of the accumulate node. This is particularly problematic because it is essentially "spooky action at a distance" (coin credit to Tom). The DAG does not track this at all since it has no formal relationship to the accumulate node. This means that any storage of the minimal DAG for this node (which only includes ancestors) will miss this critical piece of code.

I propose potential solutions to this:
1. Have a sentinel data type which when received by the accumulate node causes the node to revert to the initial state.
2. Have a secondary input connection which when emitted into causes the accumulate note to revert to the initial state.

I'm currently leaning towards 2, since I dislike making sentinels if I can avoid them, since the boil down to a special datatype which we need to worry about. Additionally emitting into a secondary stream which causes the reset of the accumulate node doesn't require us to inspect the data so this is automatically parallel safe.

This PR implements 2. This may form a generall approach for these kind of state storing nodes (eg. ``sliding_window`` or ``zip``)